### PR TITLE
Vulkan model test.

### DIFF
--- a/CervicalApp/app/build.gradle
+++ b/CervicalApp/app/build.gradle
@@ -1,15 +1,14 @@
 apply plugin: 'com.android.application'
 
 repositories {
-    jcenter()
     maven {
         url "https://oss.sonatype.org/content/repositories/snapshots"
     }
 }
 
 android {
-    compileSdkVersion 28
-    buildToolsVersion "28.0.2"
+    compileSdkVersion 30
+    buildToolsVersion '30.0.2'
     defaultConfig {
         applicationId "org.pytorch.helloworld"
         minSdkVersion 21
@@ -26,6 +25,16 @@ android {
 
 dependencies {
     implementation 'androidx.appcompat:appcompat:1.1.0'
-    implementation 'org.pytorch:pytorch_android:1.8.0'
-    implementation 'org.pytorch:pytorch_android_torchvision:1.8.0'
+    //implementation files('pytorch_android-release.aar')
+    //implementation files('pytorch_android_torchvision-release.aar')
+    //implementation 'com.facebook.soloader:nativeloader:0.10.1'
+    //implementation 'com.facebook.fbjni:fbjni-java-only:0.2.2'
+
+//  works with cpu model
+//    implementation 'org.pytorch:pytorch_android_lite:1.10.0'
+//    implementation 'org.pytorch:pytorch_android_torchvision_lite:1.10.0'
+
+    // for vulkan model
+    implementation 'org.pytorch:pytorch_android:1.10.0'
+    implementation 'org.pytorch:pytorch_android_torchvision:1.10.0'
 }

--- a/CervicalApp/app/src/main/java/org/pytorch/helloworld/MainActivity.java
+++ b/CervicalApp/app/src/main/java/org/pytorch/helloworld/MainActivity.java
@@ -14,14 +14,13 @@ import org.pytorch.IValue;
 import org.pytorch.Module;
 import org.pytorch.Tensor;
 import org.pytorch.torchvision.TensorImageUtils;
-import org.pytorch.MemoryFormat;
+import org.pytorch.Device;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.lang.Math;
-import java.nio.FloatBuffer;
 
 import androidx.appcompat.app.AppCompatActivity;
 
@@ -58,7 +57,14 @@ public class MainActivity extends AppCompatActivity {
 
       // loading serialized torchscript module from packaged into app android asset model.pt,
       // app/src/model/assets/model.pt
-      module = Module.load(assetFilePath(this, "dummy_model.ptl"));
+
+        // cpu
+        //module = LiteModuleLoader.load( assetFilePath( this, "dummy_model.ptl"));
+
+        // vulkan
+        module = Module.load ( assetFilePath(this,"dummy_model_vulkan.pt"), null, Device.VULKAN);
+
+
     } catch (IOException e) {
       Log.e("CervicalApp", "Error reading assets", e);
       finish();

--- a/CervicalApp/build.gradle
+++ b/CervicalApp/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.5.0'
+        classpath 'com.android.tools.build:gradle:7.0.2'
     }
 }
 

--- a/CervicalApp/gradle/wrapper/gradle-wrapper.properties
+++ b/CervicalApp/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-all.zip

--- a/mobile_model_conversion.py
+++ b/mobile_model_conversion.py
@@ -2,6 +2,10 @@ import torch
 import monai
 from torch.utils.mobile_optimizer import optimize_for_mobile
 
+# hack downloading model ssl verification
+import ssl
+ssl._create_default_https_context = ssl._create_unverified_context
+
 ## Download custom model weights
 # model_path = "path/to/model.pth"
 
@@ -18,4 +22,6 @@ device = "cpu"
 model.eval()
 
 torchscript_model = torch.jit.script(model)
-optimize_for_mobile(torchscript_model)._save_for_lite_interpreter("dummy_model.ptl")
+#optimize_for_mobile(torchscript_model)._save_for_lite_interpreter("dummy_model.ptl")
+torchscript_model_vulkan = optimize_for_mobile(torchscript_model, backend='vulkan')
+torch.jit.save(torchscript_model_vulkan, "dummy_model_vulkan.pt")


### PR DESCRIPTION
I'm not sure if you'll be able to duplicate creating the model.  You may have to compile PyTorch from scratch To do that.  I used the release/1.10 branch and compiled it with USE_VULKAN=1 to get the Vulkan backend support.  I did commit the model into the app's assets folder though.

I upgraded the Gradle plugin to be more current.  Those changes can be ignored if you don't want or can't use them.

The cpu model works with the lite interpreter but the Vulkan model requires the normal interpreter.  See build.gradle for switching.  I committed with it set up for Vulkan.

On my device, I have errors executing the Vulkan model.  I thought it would be useful to compare though.  I don't know if these are errors with PyTorch implementation or our device implementation of Vulkan.  May be worth trying other models or more simple models but I'm not much an expert on creating/using those.